### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Works on iPhone and iPad
 ## Installation
 
 StatusBarNotificationCenter is available through [CocoaPods](http://cocoapods.org). To install
-it, simply add the following line to your Podfile, becasue this is written in Swift 2.0, you may also need to insert `use_frameworks!` in your Podfile:
+it, simply add the following line to your Podfile, because this is written in Swift 2.0, you may also need to insert `use_frameworks!` in your Podfile:
 
 ```ruby
 pod "StatusBarNotificationCenter"


### PR DESCRIPTION
@36Kr-Mobile, I've corrected a typographical error in the documentation of the [StatusBarNotificationCenter](https://github.com/36Kr-Mobile/StatusBarNotificationCenter) project. Specifically, I've changed becasue to because. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
