### PR TITLE
Updates selector syntax.

### DIFF
--- a/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
+++ b/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
@@ -122,7 +122,7 @@ extension StatusBarNotificationCenter {
         }
         self.notificationWindow.hidden = false
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "screenOrientationChanged", name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(StatusBarNotificationCenter.screenOrientationChanged), name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
         
         UIView.animateWithDuration(self.animateInLength, animations: { () -> Void in
             self.animateInFrameChange()
@@ -154,7 +154,7 @@ extension StatusBarNotificationCenter {
         self.notificationWindow.rootViewController?.view.bringSubviewToFront(view)
         self.createSnapshotView()
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "screenOrientationChanged", name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(StatusBarNotificationCenter.screenOrientationChanged), name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
         
         UIView.animateWithDuration(self.animateInLength, animations: { () -> Void in
             self.animateInFrameChange()
@@ -311,7 +311,7 @@ extension StatusBarNotificationCenter {
         view?.clipsToBounds = true
         view?.userInteractionEnabled = true
         
-        let tapGesture = UITapGestureRecognizer(target: self, action: "notificationTapped:")
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(StatusBarNotificationCenter.notificationTapped(_:)))
         view?.addGestureRecognizer(tapGesture)
         
         switch animateInDirection {


### PR DESCRIPTION
Hi,

I changed the selector syntax from `String` to `#selector` to get rid of some compiler warnings.
The pod version number in `podspec` is not changed, because I won't break your versioning system. So this I've left over for you.

Kind regards,
Stephan
