### PR TITLE
Converts code to Swift 3.

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -385,6 +385,14 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					20BDCAA8EBA3DAB0651638321FFE2DF1 = {
+						LastSwiftMigration = 0800;
+					};
+					AF10EC977E286848FEC7CC941823D0E2 = {
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -657,6 +665,7 @@
 				PRODUCT_NAME = StatusBarNotificationCenter;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;
@@ -699,6 +708,7 @@
 				PRODUCT_NAME = StatusBarNotificationCenter;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
@@ -724,6 +734,7 @@
 				PRODUCT_NAME = StatusBarNotificationCenter;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -752,6 +763,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/StatusBarNotificationCenter.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/StatusBarNotificationCenter.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/StatusBarNotificationCenter.xcodeproj/project.pbxproj
+++ b/Example/StatusBarNotificationCenter.xcodeproj/project.pbxproj
@@ -221,14 +221,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 				};
@@ -427,8 +429,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -472,8 +476,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -492,6 +498,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -507,6 +514,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -522,6 +530,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -543,6 +552,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StatusBarNotificationCenter_Example.app/StatusBarNotificationCenter_Example";
 			};
 			name = Debug;
@@ -560,6 +570,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StatusBarNotificationCenter_Example.app/StatusBarNotificationCenter_Example";
 			};
 			name = Release;

--- a/Example/StatusBarNotificationCenter.xcodeproj/xcshareddata/xcschemes/StatusBarNotificationCenter-Example.xcscheme
+++ b/Example/StatusBarNotificationCenter.xcodeproj/xcshareddata/xcschemes/StatusBarNotificationCenter-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/StatusBarNotificationCenter/AppDelegate.swift
+++ b/Example/StatusBarNotificationCenter/AppDelegate.swift
@@ -15,30 +15,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Example/StatusBarNotificationCenter/Main View Controller/ViewController.swift
+++ b/Example/StatusBarNotificationCenter/Main View Controller/ViewController.swift
@@ -26,7 +26,7 @@ class ViewController: UIViewController {
     
     @IBOutlet weak var heightSlider: UISlider!
 
-    let notificationQ = dispatch_queue_create("ViewControllerNotificationQ", DISPATCH_QUEUE_CONCURRENT)
+    let notificationQ = DispatchQueue(label: "ViewControllerNotificationQ", attributes: DispatchQueue.Attributes.concurrent)
     
     var notificationCenter: StatusBarNotificationCenter!
 
@@ -36,46 +36,46 @@ class ViewController: UIViewController {
         notificationTextField.text = "Hello, Programmer"
     }
     
-    @IBAction func durationValueChanged(sender: UISlider) {
+    @IBAction func durationValueChanged(_ sender: UISlider) {
         let labelText = "\(sender.value) seconds"
         durationLabel.text = labelText
     }
     
-    @IBAction func heightValueChanged(sender: UISlider) {
+    @IBAction func heightValueChanged(_ sender: UISlider) {
         let labelText = sender.value == 0 ? "Standard Height" : "\(sender.value) of the screen height"
         heightLabel.text = labelText
     }
 
-    @IBAction func notificationNumberChanged(sender: UISlider) {
+    @IBAction func notificationNumberChanged(_ sender: UISlider) {
         let labelText = "\(Int(concurrentNotificationNumberSlider.value))"
         concurrentNotificationNumberLabel.text = labelText
     }
     
 
-    @IBAction func showNotification(sender: UIButton) {
+    @IBAction func showNotification(_ sender: UIButton) {
         var notificationCenterConfiguration = NotificationCenterConfiguration(baseWindow: view.window!)
         notificationCenterConfiguration.animateInDirection = StatusBarNotificationCenter.AnimationDirection(rawValue: segFromStyle.selectedSegmentIndex)!
         notificationCenterConfiguration.animateOutDirection = StatusBarNotificationCenter.AnimationDirection(rawValue: segToStyle.selectedSegmentIndex)!
         notificationCenterConfiguration.animationType = StatusBarNotificationCenter.AnimationType(rawValue: segAnimationType.selectedSegmentIndex)!
         notificationCenterConfiguration.style = StatusBarNotificationCenter.Style(rawValue: segNotificationType.selectedSegmentIndex)!
-        notificationCenterConfiguration.height = (UIScreen.mainScreen().bounds.height * CGFloat(heightSlider.value))
+        notificationCenterConfiguration.height = (UIScreen.main.bounds.height * CGFloat(heightSlider.value))
         notificationCenterConfiguration.animateInLength = 0.25
         notificationCenterConfiguration.animateOutLength = 0.75
         notificationCenterConfiguration.style = StatusBarNotificationCenter.Style(rawValue: segNotificationType.selectedSegmentIndex)!
-        dispatch_async(notificationQ) { () -> Void in
+        notificationQ.async { () -> Void in
             for i in 1...Int(self.concurrentNotificationNumberSlider.value) {
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(Double(i) * drand48() * Double(NSEC_PER_SEC))), dispatch_get_main_queue(), { () -> Void in
-                    if self.isCustomView.on {
-                        let nibContents = NSBundle.mainBundle().loadNibNamed("NotificationView", owner: self, options: nil)
-                        let view = nibContents.first as! UIView
-                        StatusBarNotificationCenter.showStatusBarNotificationWithView(view, forDuration: NSTimeInterval(self.durationSlider.value), withNotificationCenterConfiguration: notificationCenterConfiguration)
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(i) * drand48() * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: { () -> Void in
+                    if self.isCustomView.isOn {
+                        let nibContents = Bundle.main.loadNibNamed("NotificationView", owner: self, options: nil)
+                        let view = nibContents?.first as! UIView
+                        StatusBarNotificationCenter.showStatusBarNotificationWithView(view, forDuration: TimeInterval(self.durationSlider.value), withNotificationCenterConfiguration: notificationCenterConfiguration)
                     } else {
                         var notificationLabelConfiguration = NotificationLabelConfiguration()
-                        notificationLabelConfiguration.font = UIFont.systemFontOfSize(14.0)
-                        notificationLabelConfiguration.multiline = self.multiLine.on
+                        notificationLabelConfiguration.font = UIFont.systemFont(ofSize: 14.0)
+                        notificationLabelConfiguration.multiline = self.multiLine.isOn
                         notificationLabelConfiguration.backgroundColor = self.view.tintColor
-                        notificationLabelConfiguration.textColor = UIColor.blackColor()
-                        StatusBarNotificationCenter.showStatusBarNotificationWithMessage(self.notificationTextField.text! + "\(i)", forDuration: NSTimeInterval(self.durationSlider.value), withNotificationCenterConfiguration: notificationCenterConfiguration, andNotificationLabelConfiguration: notificationLabelConfiguration)
+                        notificationLabelConfiguration.textColor = UIColor.black
+                        StatusBarNotificationCenter.showStatusBarNotificationWithMessage(self.notificationTextField.text! + "\(i)", forDuration: TimeInterval(self.durationSlider.value), withNotificationCenterConfiguration: notificationCenterConfiguration, andNotificationLabelConfiguration: notificationLabelConfiguration)
                     }
                     
                 })

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -21,7 +21,7 @@ class Tests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock() {
+        self.measure() {
             // Put the code you want to measure the time of here.
         }
     }

--- a/Pod/Configuration/NotificationCenterConfiguration.swift
+++ b/Pod/Configuration/NotificationCenterConfiguration.swift
@@ -15,19 +15,19 @@ public struct NotificationCenterConfiguration {
     /// The window below the notification window, you must set this property, or the notification will not work correctly
     var baseWindow: UIWindow
     /// The style of the notification, default to status bar notification
-    public var style = StatusBarNotificationCenter.Style.StatusBar
+    public var style = StatusBarNotificationCenter.Style.statusBar
     /// The animation type of the notification, default to overlay
-    public var animationType = StatusBarNotificationCenter.AnimationType.Overlay
+    public var animationType = StatusBarNotificationCenter.AnimationType.overlay
     /// The animate in direction of the notification, default to top
-    public var animateInDirection = StatusBarNotificationCenter.AnimationDirection.Top
+    public var animateInDirection = StatusBarNotificationCenter.AnimationDirection.top
     /// The animate out direction of the notification, default to top
-    public var animateOutDirection = StatusBarNotificationCenter.AnimationDirection.Top
+    public var animateOutDirection = StatusBarNotificationCenter.AnimationDirection.top
     /// Whether the user can tap on the notification to dismiss the notification, default to true
     public var dismissible = true
     /// The animate in time of the notification
-    public var animateInLength: NSTimeInterval = 0.25
+    public var animateInLength: TimeInterval = 0.25
     /// The animate out time of the notification
-    public var animateOutLength: NSTimeInterval = 0.25
+    public var animateOutLength: TimeInterval = 0.25
     /// The height of the notification view, if you want to use a custom height, set the style of the notification to custom, or it will use the status bar and navigation bar height
     public var height: CGFloat = 0
     /// If the status bar is hidden, if it is hidden, the hight of the navigation style notification height is the height of the navigation bar, default to false

--- a/Pod/Configuration/NotificationLabelConfiguration.swift
+++ b/Pod/Configuration/NotificationLabelConfiguration.swift
@@ -15,7 +15,7 @@ public struct NotificationLabelConfiguration {
     /// if the label should scroll the content, default to false
     public var scrollabel = true
     /// If you set the scrollabel property to true, you can use this property to customize the scroll delay, default delay is 1 second
-    public var scrollDelay: NSTimeInterval = 1.0
+    public var scrollDelay: TimeInterval = 1.0
     /// If you set the scrollabel property to true, you can use this property to customize the scroll speed, default speed is 40 points per second
     public var scrollSpeed: CGFloat = 40.0
     /// Set the padding of the message label, default to 10.0 points
@@ -23,11 +23,11 @@ public struct NotificationLabelConfiguration {
     /// if the label should be multiline implementation, default to false
     public var multiline = false
     /// The background color of the notification view, default to black color
-    public var backgroundColor = UIColor.blackColor()
+    public var backgroundColor = UIColor.black
     /// The text color of the notification view, default to white color
-    public var textColor = UIColor.whiteColor()
+    public var textColor = UIColor.white
     /// The font of the notification label, defalt to a system font of size 14.0, if you pass the attributed string, this property will be ignored
-    public var font = UIFont.systemFontOfSize(StatusBarNotificationCenter.defaultMessageLabelFontSize)
+    public var font = UIFont.systemFont(ofSize: StatusBarNotificationCenter.defaultMessageLabelFontSize)
     /// this property is not nil, the label will use the attributed string to show the message
     public var attributedText: NSAttributedString? = nil
     

--- a/Pod/Notification Center/BaseScrollLabel.swift
+++ b/Pod/Notification Center/BaseScrollLabel.swift
@@ -15,46 +15,46 @@ class BaseScrollLabel: UILabel {
     var messageImage = UIImageView()
     var scrollable: Bool = true
     var scrollSpeed: CGFloat = 40.0
-    var scrollDelay: NSTimeInterval = 1.0
+    var scrollDelay: TimeInterval = 1.0
     var padding: CGFloat = 10.0
     
     var fullWidth: CGFloat {
         guard let message = text else { return 0 }
-        return (message as NSString).sizeWithAttributes([NSFontAttributeName : font]).width
+        return (message as NSString).size(attributes: [NSFontAttributeName : font]).width
     }
     
     var scrollOffset: CGFloat {
         if (numberOfLines != 1) || !scrollable { return 0 }
-        let insetRect = CGRectInset(bounds, padding, 0)
-        return max(0, fullWidth - CGRectGetWidth(insetRect))
+        let insetRect = bounds.insetBy(dx: padding, dy: 0)
+        return max(0, fullWidth - insetRect.width)
     }
     
-    var scrollTime: NSTimeInterval {
-        return (scrollOffset > 0) ? NSTimeInterval(scrollOffset / scrollSpeed) + scrollDelay : 0
+    var scrollTime: TimeInterval {
+        return (scrollOffset > 0) ? TimeInterval(scrollOffset / scrollSpeed) + scrollDelay : 0
     }
     
-    override func drawTextInRect(rect: CGRect) {
+    override func drawText(in rect: CGRect) {
         var rect = rect
         if scrollOffset > 0 {
             rect.size.width = fullWidth + padding * 2
             
-            UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.mainScreen().scale)
-            super.drawTextInRect(rect)
+            UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.main.scale)
+            super.drawText(in: rect)
             messageImage.image = UIGraphicsGetImageFromCurrentImageContext()
             UIGraphicsEndImageContext()
             
             messageImage.sizeToFit()
             addSubview(messageImage)
             
-            UIView.animateWithDuration(scrollTime - scrollDelay, delay: scrollDelay, options: [.BeginFromCurrentState, .CurveEaseInOut], animations: { () -> Void in
-                self.messageImage.transform = CGAffineTransformMakeTranslation(-self.scrollOffset, 0)
+            UIView.animate(withDuration: scrollTime - scrollDelay, delay: scrollDelay, options: .beginFromCurrentState, animations: { () -> Void in
+                self.messageImage.transform = CGAffineTransform(translationX: -self.scrollOffset, y: 0)
             }, completion: { (finished) -> Void in
                 //
             })
             
         } else {
             messageImage.removeFromSuperview()
-            super.drawTextInRect(CGRectInset(rect, padding, padding))
+            super.drawText(in: rect.insetBy(dx: padding, dy: padding))
         }
     }
 }

--- a/Pod/Notification Center/BaseWindow.swift
+++ b/Pod/Notification Center/BaseWindow.swift
@@ -15,9 +15,9 @@ class BaseWindow: UIWindow {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        backgroundColor = UIColor.clearColor()
-        userInteractionEnabled = true
-        hidden = true
+        backgroundColor = UIColor.clear
+        isUserInteractionEnabled = true
+        isHidden = true
         windowLevel = UIWindowLevelNormal
         rootViewController = BaseViewController()
     }
@@ -34,9 +34,9 @@ class BaseWindow: UIWindow {
       }
     }
 
-    override func hitTest(pt: CGPoint, withEvent event: UIEvent?) -> UIView? {
+    override func hitTest(_ pt: CGPoint, with event: UIEvent?) -> UIView? {
         if pt.y > 0 && pt.y < (notificationCenter.internalnotificationViewHeight) {
-                return super.hitTest(pt, withEvent: event)
+                return super.hitTest(pt, with: event)
         }
         return nil
     }

--- a/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
+++ b/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
@@ -18,8 +18,8 @@ extension StatusBarNotificationCenter {
     - parameter duration:                        the showing time of the notification
     - parameter notificationCenterConfiguration: the notification configuration
     */
-    public class func showStatusBarNotificationWithView(view: UIView, forDuration duration: NSTimeInterval, withNotificationCenterConfiguration notificationCenterConfiguration: NotificationCenterConfiguration) {
-        let notification = Notification(view: view, message:nil, notificationCenterConfiguration: notificationCenterConfiguration, viewSource: .CustomView, notificationLabelConfiguration: nil, duration: duration, completionHandler: nil)
+    public class func showStatusBarNotificationWithView(_ view: UIView, forDuration duration: TimeInterval, withNotificationCenterConfiguration notificationCenterConfiguration: NotificationCenterConfiguration) {
+        let notification = Notification(view: view, message:nil, notificationCenterConfiguration: notificationCenterConfiguration, viewSource: .customView, notificationLabelConfiguration: nil, duration: duration, completionHandler: nil)
         StatusBarNotificationCenter.center.processNotification(notification)
     }
     
@@ -30,8 +30,8 @@ extension StatusBarNotificationCenter {
     - parameter notificationCenterConfiguration: the notification configuration
     - parameter completionHandler:               the block to be invoked when the notification is being showed
     */
-    public class func showStatusBarNotificationWithView(view: UIView, withNotificationCenterConfiguration notificationCenterConfiguration: NotificationCenterConfiguration, whenComplete completionHandler: (Void -> Void)? = nil) {
-        let notification = Notification(view: view, message:nil, notificationCenterConfiguration: notificationCenterConfiguration, viewSource: .CustomView, notificationLabelConfiguration: nil, duration: nil, completionHandler: completionHandler)
+    public class func showStatusBarNotificationWithView(_ view: UIView, withNotificationCenterConfiguration notificationCenterConfiguration: NotificationCenterConfiguration, whenComplete completionHandler: ((Void) -> Void)? = nil) {
+        let notification = Notification(view: view, message:nil, notificationCenterConfiguration: notificationCenterConfiguration, viewSource: .customView, notificationLabelConfiguration: nil, duration: nil, completionHandler: completionHandler)
         StatusBarNotificationCenter.center.processNotification(notification)
     }
 
@@ -43,8 +43,8 @@ extension StatusBarNotificationCenter {
     - parameter notificationCenterConfiguration:   the notification configuration
     - parameter andNotificationLabelConfiguration: the label configuration
     */
-    public class func showStatusBarNotificationWithMessage(message: String?, forDuration duration: NSTimeInterval, withNotificationCenterConfiguration notificationCenterConfiguration: NotificationCenterConfiguration, andNotificationLabelConfiguration notificationLabelConfiguration: NotificationLabelConfiguration) {
-        let notification = Notification(view: nil, message:message, notificationCenterConfiguration: notificationCenterConfiguration, viewSource: .Label, notificationLabelConfiguration: notificationLabelConfiguration, duration: duration, completionHandler: nil)
+    public class func showStatusBarNotificationWithMessage(_ message: String?, forDuration duration: TimeInterval, withNotificationCenterConfiguration notificationCenterConfiguration: NotificationCenterConfiguration, andNotificationLabelConfiguration notificationLabelConfiguration: NotificationLabelConfiguration) {
+        let notification = Notification(view: nil, message:message, notificationCenterConfiguration: notificationCenterConfiguration, viewSource: .label, notificationLabelConfiguration: notificationLabelConfiguration, duration: duration, completionHandler: nil)
         StatusBarNotificationCenter.center.processNotification(notification)
     }
     
@@ -56,8 +56,8 @@ extension StatusBarNotificationCenter {
     - parameter andNotificationLabelConfiguration: the label configuration
     - parameter completionHandler:               the block to be invoked when the notification is being showed
     */
-    public class func showStatusBarNotificationWithMessage(message: String?, withNotificationCenterConfiguration notificationCenterConfiguration: NotificationCenterConfiguration, andNotificationLabelConfiguration notificationLabelConfiguration: NotificationLabelConfiguration, whenComplete completionHandler: (Void -> Void)? = nil) {
-        let notification = Notification(view: nil, message:message, notificationCenterConfiguration: notificationCenterConfiguration, viewSource: .Label, notificationLabelConfiguration: notificationLabelConfiguration, duration: nil, completionHandler: completionHandler)
+    public class func showStatusBarNotificationWithMessage(_ message: String?, withNotificationCenterConfiguration notificationCenterConfiguration: NotificationCenterConfiguration, andNotificationLabelConfiguration notificationLabelConfiguration: NotificationLabelConfiguration, whenComplete completionHandler: ((Void) -> Void)? = nil) {
+        let notification = Notification(view: nil, message:message, notificationCenterConfiguration: notificationCenterConfiguration, viewSource: .label, notificationLabelConfiguration: notificationLabelConfiguration, duration: nil, completionHandler: completionHandler)
         StatusBarNotificationCenter.center.processNotification(notification)
     }
     
@@ -66,8 +66,8 @@ extension StatusBarNotificationCenter {
     
     - parameter notification: the notification to be processed
     */
-    func processNotification(notification: Notification) {
-      dispatch_async(notificationQ) { () -> Void in
+    func processNotification(_ notification: Notification) {
+      notificationQ.async { () -> Void in
         StatusBarNotificationCenter.center.notifications.append(notification)
         StatusBarNotificationCenter.center.showNotification()
       }
@@ -77,8 +77,8 @@ extension StatusBarNotificationCenter {
     This is the hub of all notifications, just use a semaphore to manage the showing process
     */
     func showNotification() {
-        if (dispatch_semaphore_wait(self.notificationSemaphore, DISPATCH_TIME_FOREVER) == 0) {
-            dispatch_sync(dispatch_get_main_queue(), { () -> Void in
+        if (self.notificationSemaphore.wait(timeout: DispatchTime.distantFuture) == .success) {
+            DispatchQueue.main.sync(execute: { () -> Void in
               if self.notifications.count > 0 {
                 let currentNotification = self.notifications.removeFirst()
                 
@@ -86,16 +86,16 @@ extension StatusBarNotificationCenter {
                 self.notificationLabelConfiguration = currentNotification.notificationLabelConfiguration
                     self.notificationWindow.resetRootViewController()
                     switch currentNotification.viewSource {
-                    case .CustomView:
-                        self.viewSource = .CustomView
+                    case .customView:
+                        self.viewSource = .customView
                         
                         if let duration = currentNotification.duration {
                             self.showStatusBarNotificationWithView(currentNotification.view, forDuration: duration)
                         } else {
                             self.showStatusBarNotificationWithView(currentNotification.view, completion: currentNotification.completionHandler)
                         }
-                    case .Label:
-                        self.viewSource = .Label
+                    case .label:
+                        self.viewSource = .label
                         
                         if let duration = currentNotification.duration {
                             self.showStatusBarNotificationWithMessage(currentNotification.message, forDuration: duration)
@@ -110,7 +110,7 @@ extension StatusBarNotificationCenter {
         }
     }
   
-    func showStatusBarNotificationWithMessage(message: String?,completion: (() -> Void)?) {
+    func showStatusBarNotificationWithMessage(_ message: String?,completion: (() -> Void)?) {
         
         self.createMessageLabelWithMessage(message)
         self.createSnapshotView()
@@ -118,17 +118,17 @@ extension StatusBarNotificationCenter {
         
         if let messageLabel = self.messageLabel {
             self.notificationWindow.rootViewController?.view.addSubview(messageLabel)
-            self.notificationWindow.rootViewController?.view.bringSubviewToFront(messageLabel)
+            self.notificationWindow.rootViewController?.view.bringSubview(toFront: messageLabel)
         }
-        self.notificationWindow.hidden = false
+        self.notificationWindow.isHidden = false
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(StatusBarNotificationCenter.screenOrientationChanged), name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(StatusBarNotificationCenter.screenOrientationChanged), name: NSNotification.Name.UIApplicationDidChangeStatusBarOrientation, object: nil)
         
-        UIView.animateWithDuration(self.animateInLength, animations: { () -> Void in
+        UIView.animate(withDuration: self.animateInLength, animations: { () -> Void in
             self.animateInFrameChange()
             }, completion: { (finished) -> Void in
                 let delayInSeconds = self.messageLabel.scrollTime
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(delayInSeconds * Double(NSEC_PER_SEC))), dispatch_get_main_queue(), { () -> Void in
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(delayInSeconds * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: { () -> Void in
                     if let completion = completion {
                         completion()
                     }
@@ -137,26 +137,26 @@ extension StatusBarNotificationCenter {
         
     }
   
-    func showStatusBarNotificationWithMessage(message: String?, forDuration duration: NSTimeInterval) {
+    func showStatusBarNotificationWithMessage(_ message: String?, forDuration duration: TimeInterval) {
         self.showStatusBarNotificationWithMessage(message) { () -> Void in
-          dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(Double(duration) * Double(NSEC_PER_SEC))), dispatch_get_main_queue(), { () -> Void in
+          DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(duration) * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: { () -> Void in
             self.dismissNotification()
           })
         }
     }
     
-    func showStatusBarNotificationWithView(view: UIView, completion: (Void -> Void)?) {
+    func showStatusBarNotificationWithView(_ view: UIView, completion: ((Void) -> Void)?) {
         
-        self.notificationWindow.hidden = false
+        self.notificationWindow.isHidden = false
         
         self.customView = view
         self.notificationWindow.rootViewController?.view.addSubview(view)
-        self.notificationWindow.rootViewController?.view.bringSubviewToFront(view)
+        self.notificationWindow.rootViewController?.view.bringSubview(toFront: view)
         self.createSnapshotView()
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(StatusBarNotificationCenter.screenOrientationChanged), name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(StatusBarNotificationCenter.screenOrientationChanged), name: NSNotification.Name.UIApplicationDidChangeStatusBarOrientation, object: nil)
         
-        UIView.animateWithDuration(self.animateInLength, animations: { () -> Void in
+        UIView.animate(withDuration: self.animateInLength, animations: { () -> Void in
             self.animateInFrameChange()
             }, completion: { (finished) -> Void in
                 completion?()
@@ -164,9 +164,9 @@ extension StatusBarNotificationCenter {
         
     }
   
-    func showStatusBarNotificationWithView(view: UIView, forDuration duration: NSTimeInterval) {
+    func showStatusBarNotificationWithView(_ view: UIView, forDuration duration: TimeInterval) {
         self.showStatusBarNotificationWithView(view) { () -> Void in
-          dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(Double(duration) * Double(NSEC_PER_SEC))), dispatch_get_main_queue(), { () -> Void in
+          DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(duration) * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: { () -> Void in
             self.dismissNotification()
           })
         }
@@ -177,17 +177,17 @@ extension StatusBarNotificationCenter {
     
     - parameter completion: completion handler to invoke when the dismiss procedure finished
     */
-    public class func dismissNotificationWithCompletion(completion: (() -> Void)?) {
+    public class func dismissNotificationWithCompletion(_ completion: (() -> Void)?) {
         StatusBarNotificationCenter.center.dismissNotificationWithCompletion(completion)
     }
     
-    func dismissNotificationWithCompletion(completion: (() -> Void)?) {
+    func dismissNotificationWithCompletion(_ completion: (() -> Void)?) {
         
         self.middleFrameChange()
-        UIView.animateWithDuration(self.animateOutLength, animations: { () -> Void in
+        UIView.animate(withDuration: self.animateOutLength, animations: { () -> Void in
           self.animateOutFrameChange()
           }, completion: { (finished) -> Void in
-            self.notificationWindow.hidden = true
+            self.notificationWindow.isHidden = true
             self.messageLabel = nil
             self.snapshotView = nil
             self.customView = nil
@@ -195,13 +195,13 @@ extension StatusBarNotificationCenter {
             self.notificationLabelConfiguration = nil
             self.notificationCenterConfiguration = nil
             
-            NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIApplicationDidChangeStatusBarOrientation, object: nil)
             
             if let completion = completion {
               completion()
             }
             
-            dispatch_semaphore_signal(self.notificationSemaphore)
+            self.notificationSemaphore.signal()
         })
     }
   
@@ -214,15 +214,15 @@ extension StatusBarNotificationCenter {
     
     //MARK: - Handle Change
     
-    func notificationTapped(tapGesture: UITapGestureRecognizer) {
+    func notificationTapped(_ tapGesture: UITapGestureRecognizer) {
         dismissNotification()
     }
     
     func screenOrientationChanged() {
         switch viewSource {
-        case .Label:
+        case .label:
             messageLabel?.frame = notificationViewFrame
-        case .CustomView:
+        case .customView:
             customView?.frame = notificationViewFrame
         }
     }
@@ -232,35 +232,35 @@ extension StatusBarNotificationCenter {
     func animateInFrameChange() {
         let view: UIView?
         switch viewSource {
-        case .Label:
+        case .label:
             view = messageLabel
-        case .CustomView:
+        case .customView:
             view = customView
         }
         
         view?.frame = notificationViewFrame
         
         switch animateInDirection {
-        case .Top:
+        case .top:
             snapshotView?.frame = notificationViewBottomFrame
-        case .Left:
+        case .left:
             snapshotView?.frame = notificationViewRightFrame
-        case .Right:
+        case .right:
             snapshotView?.frame = notificationViewLeftFrame
-        case .Bottom:
+        case .bottom:
             snapshotView?.frame = notificationViewTopFrame
         }
     }
     
     func middleFrameChange() {
         switch animateOutDirection {
-        case .Top:
+        case .top:
             snapshotView?.frame = notificationViewBottomFrame
-        case .Left:
+        case .left:
             snapshotView?.frame = notificationViewRightFrame
-        case .Right:
+        case .right:
             snapshotView?.frame = notificationViewLeftFrame
-        case .Bottom:
+        case .bottom:
             snapshotView?.frame = notificationViewTopFrame
         }
     }
@@ -268,31 +268,31 @@ extension StatusBarNotificationCenter {
     func animateOutFrameChange() {
         let view: UIView?
         switch viewSource {
-        case .Label:
+        case .label:
             view = messageLabel
-        case .CustomView:
+        case .customView:
             view = customView
         }
         
         snapshotView?.frame = notificationViewFrame
         switch animateOutDirection {
-        case .Top:
+        case .top:
             view?.frame = notificationViewTopFrame
-        case .Left:
+        case .left:
             view?.frame = notificationViewLeftFrame
-        case .Right:
+        case .right:
             view?.frame = notificationViewRightFrame
-        case .Bottom:
+        case .bottom:
             view?.frame = notificationViewBottomFrame
         }
     }
     
     //MARK: - Helper view creation
     
-    func createMessageLabelWithMessage(message: String?) {
+    func createMessageLabelWithMessage(_ message: String?) {
         messageLabel = BaseScrollLabel()
         messageLabel?.text = message
-        messageLabel?.textAlignment = .Center
+        messageLabel?.textAlignment = .center
         messageLabel?.font = messageLabelFont
         messageLabel?.numberOfLines = messageLabelMultiline ? 0 : 1
         messageLabel?.textColor = messageLabelTextColor
@@ -307,35 +307,35 @@ extension StatusBarNotificationCenter {
         setupNotificationView(messageLabel)
     }
     
-    func setupNotificationView(view: UIView?) {
+    func setupNotificationView(_ view: UIView?) {
         view?.clipsToBounds = true
-        view?.userInteractionEnabled = true
+        view?.isUserInteractionEnabled = true
         
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(StatusBarNotificationCenter.notificationTapped(_:)))
         view?.addGestureRecognizer(tapGesture)
         
         switch animateInDirection {
-        case .Top:
+        case .top:
             view?.frame = notificationViewTopFrame
-        case .Left:
+        case .left:
             view?.frame = notificationViewLeftFrame
-        case .Right:
+        case .right:
             view?.frame = notificationViewRightFrame
-        case .Bottom:
+        case .bottom:
             view?.frame = notificationViewBottomFrame
         }
     }
 
     func createSnapshotView() {
-        if animationType != .Replace { return }
+        if animationType != .replace { return }
         
         snapshotView = UIView(frame: notificationViewFrame)
         snapshotView!.clipsToBounds = true
-        snapshotView!.backgroundColor = UIColor.clearColor()
+        snapshotView!.backgroundColor = UIColor.clear
         
-        let view = baseWindow.snapshotViewAfterScreenUpdates(true)
-        snapshotView!.addSubview(view)
+        let view = baseWindow.snapshotView(afterScreenUpdates: true)
+        snapshotView!.addSubview(view!)
         notificationWindow.rootViewController?.view.addSubview(snapshotView!)
-        notificationWindow.rootViewController?.view.sendSubviewToBack(snapshotView!)
+        notificationWindow.rootViewController?.view.sendSubview(toBack: snapshotView!)
     }
 }

--- a/Pod/Notification Center/StatusBarNotificationCenter+Type.swift
+++ b/Pod/Notification Center/StatusBarNotificationCenter+Type.swift
@@ -21,15 +21,15 @@ extension StatusBarNotificationCenter {
         /**
         *  Covers the statusbar portion of the screen, if the status bar is hidden, cover the status bar height of the screen
         */
-        case StatusBar
+        case statusBar
         /**
         *  Covers the status bar and navigation bar portion of the screen
         */
-        case NavigationBar
+        case navigationBar
         /**
         *  Cover part of the screen, based on the height of the configuration
         */
-        case Custom
+        case custom
     }
     
     /**
@@ -44,19 +44,19 @@ extension StatusBarNotificationCenter {
         /**
         *  Animate in from the top or animate out to the top
         */
-        case Top
+        case top
         /**
         *  Animate in from the bottom or animate out to the bottom
         */
-        case Bottom
+        case bottom
         /**
         *  Animate in from the left or animate out to the left
         */
-        case Left
+        case left
         /**
         *  Animate in from the right or animate out to the right
         */
-        case Right
+        case right
     }
     
     /**
@@ -69,11 +69,11 @@ extension StatusBarNotificationCenter {
         /**
         *  Moves existing content out of the way
         */
-        case Replace
+        case replace
         /**
         *  Ovelays existing content
         */
-        case Overlay
+        case overlay
     }
     
     /**
@@ -86,11 +86,11 @@ extension StatusBarNotificationCenter {
         /**
         *    Use a custom view to show the notification
         */
-        case CustomView
+        case customView
         /**
         *    Use the default label to show the notification
         */
-        case Label
+        case label
     }
     
     /**
@@ -102,13 +102,13 @@ extension StatusBarNotificationCenter {
         /// This the notification label configuration object
         let notificationLabelConfiguration: NotificationLabelConfiguration?
         /// This is the duration of the notification
-        let duration: NSTimeInterval?
+        let duration: TimeInterval?
         /// The view source of the notification
         let viewSource: ViewSource
         /// The view of the notification, if the view  source is a custom view
         let view: UIView!
         /// The completion handler to be called when the show process is done
-        let completionHandler: (Void -> Void)?
+        let completionHandler: ((Void) -> Void)?
         /// The message of the notification, if the view  source is a label
         let message: String!
 
@@ -124,7 +124,7 @@ extension StatusBarNotificationCenter {
 
         - returns: a newly initialtiated notification
         */
-      init(view: UIView?, message: String?, notificationCenterConfiguration: NotificationCenterConfiguration, viewSource: ViewSource, notificationLabelConfiguration:NotificationLabelConfiguration?, duration: NSTimeInterval?, completionHandler: (Void -> Void)?) {
+      init(view: UIView?, message: String?, notificationCenterConfiguration: NotificationCenterConfiguration, viewSource: ViewSource, notificationLabelConfiguration:NotificationLabelConfiguration?, duration: TimeInterval?, completionHandler: ((Void) -> Void)?) {
             self.view = view
             self.message = message
             self.notificationCenterConfiguration = notificationCenterConfiguration

--- a/Pod/Notification Center/StatusBarNotificationCenter.swift
+++ b/Pod/Notification Center/StatusBarNotificationCenter.swift
@@ -9,10 +9,10 @@
 import UIKit
 
 /// This is the base class of the notification center object, mainly to define properties
-public class StatusBarNotificationCenter: NSObject {
+open class StatusBarNotificationCenter: NSObject {
     //MARK: - Initializers
     
-    private override init() {
+    fileprivate override init() {
         super.init()
 
         notificationWindow.notificationCenter = self
@@ -73,7 +73,7 @@ public class StatusBarNotificationCenter: NSObject {
             fatalError("Cannot reach this branch")
         }
     }
-    var messageLabelScrollDelay: NSTimeInterval {
+    var messageLabelScrollDelay: TimeInterval {
         if let notificationLabelConfiguration = notificationLabelConfiguration {
             return notificationLabelConfiguration.scrollDelay
         } else {
@@ -111,37 +111,37 @@ public class StatusBarNotificationCenter: NSObject {
     }
     var internalnotificationViewHeight: CGFloat {
         switch notificationStyle {
-        case .StatusBar:
+        case .statusBar:
             return statusBarHeight
-        case .NavigationBar:
+        case .navigationBar:
             if statusBarIsHidden {
                 return navigationBarHeight
             } else {
                 return statusBarHeight + navigationBarHeight
             }
-        case .Custom:
+        case .custom:
             return notificationViewHeight
         }
     }
 
     var notificationViewFrame: CGRect {
-        return CGRectMake(0, 0, notificationViewWidth, internalnotificationViewHeight)
+        return CGRect(x: 0, y: 0, width: notificationViewWidth, height: internalnotificationViewHeight)
     }
     var notificationViewTopFrame: CGRect {
-        return CGRectMake(0, -internalnotificationViewHeight, notificationViewWidth, internalnotificationViewHeight)
+        return CGRect(x: 0, y: -internalnotificationViewHeight, width: notificationViewWidth, height: internalnotificationViewHeight)
     }
     var notificationViewLeftFrame: CGRect {
-        return CGRectMake(-notificationViewWidth, 0, notificationViewWidth, internalnotificationViewHeight)
+        return CGRect(x: -notificationViewWidth, y: 0, width: notificationViewWidth, height: internalnotificationViewHeight)
     }
     var notificationViewRightFrame: CGRect {
-        return CGRectMake(notificationViewWidth, 0, notificationViewWidth, internalnotificationViewHeight)
+        return CGRect(x: notificationViewWidth, y: 0, width: notificationViewWidth, height: internalnotificationViewHeight)
     }
     var notificationViewBottomFrame: CGRect {
-        return CGRectMake(0, internalnotificationViewHeight, notificationViewWidth, 0)
+        return CGRect(x: 0, y: internalnotificationViewHeight, width: notificationViewWidth, height: 0)
     }
         
     //MARK: Custom View
-    var viewSource: ViewSource = .Label
+    var viewSource: ViewSource = .label
     var customView: UIView? {
         didSet {
             if customView != nil {
@@ -196,7 +196,7 @@ public class StatusBarNotificationCenter: NSObject {
     }
     
     //MARK: - Window
-    let notificationWindow = BaseWindow(frame: UIScreen.mainScreen().bounds)
+    let notificationWindow = BaseWindow(frame: UIScreen.main.bounds)
     
     var baseWindow: UIWindow {
         if let notificationCenterConfiguration = notificationCenterConfiguration {
@@ -217,14 +217,14 @@ public class StatusBarNotificationCenter: NSObject {
             return false
         }
     }
-    var animateInLength: NSTimeInterval {
+    var animateInLength: TimeInterval {
         if let notificationCenterConfiguration = notificationCenterConfiguration {
             return notificationCenterConfiguration.animateInLength
         } else {
             fatalError("Cannot reach this branch")
         }
     }
-    var animateOutLength: NSTimeInterval {
+    var animateOutLength: TimeInterval {
         if let notificationCenterConfiguration = notificationCenterConfiguration {
             return notificationCenterConfiguration.animateOutLength
         } else {
@@ -236,9 +236,9 @@ public class StatusBarNotificationCenter: NSObject {
     /// A notification array
     var notifications = [Notification]()
     /// Create a notification Queue to track the notifications
-    let notificationQ = dispatch_queue_create("notificationQueue", DISPATCH_QUEUE_SERIAL)
+    let notificationQ = DispatchQueue(label: "notificationQueue", attributes: [])
     /// Create a semaphore to show the notification in a one-after one basis
-    let notificationSemaphore = dispatch_semaphore_create(1)
+    let notificationSemaphore = DispatchSemaphore(value: 1)
 
 
     //MARK: - User Interaction


### PR DESCRIPTION
The code is migrated to Swift version 3.0.
Maybe it will be better to integrate this in a separate branch or explicitly note it in the docu of the next new version.
