### PR TITLE
Some fixes for dismissing notifications.

### DIFF
--- a/Example/StatusBarNotificationCenter.xcodeproj/project.pbxproj
+++ b/Example/StatusBarNotificationCenter.xcodeproj/project.pbxproj
@@ -460,6 +460,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -499,6 +500,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
+++ b/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
@@ -311,19 +311,21 @@ extension StatusBarNotificationCenter {
     func setupNotificationView(_ view: UIView?) {
         view?.clipsToBounds = true
         view?.isUserInteractionEnabled = true
-        
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(StatusBarNotificationCenter.notificationTapped(_:)))
-        view?.addGestureRecognizer(tapGesture)
-        
+		
+		if self.dismissible {
+			let tapGesture = UITapGestureRecognizer(target: self, action: #selector(StatusBarNotificationCenter.notificationTapped(_:)))
+			view?.addGestureRecognizer(tapGesture)
+		}
+		
         switch animateInDirection {
-        case .top:
-            view?.frame = notificationViewTopFrame
-        case .left:
-            view?.frame = notificationViewLeftFrame
-        case .right:
-            view?.frame = notificationViewRightFrame
-        case .bottom:
-            view?.frame = notificationViewBottomFrame
+			case .top:
+				view?.frame = notificationViewTopFrame
+			case .left:
+				view?.frame = notificationViewLeftFrame
+			case .right:
+				view?.frame = notificationViewRightFrame
+			case .bottom:
+				view?.frame = notificationViewBottomFrame
         }
     }
 

--- a/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
+++ b/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
@@ -110,7 +110,7 @@ extension StatusBarNotificationCenter {
         }
     }
   
-    func showStatusBarNotificationWithMessage(_ message: String?,completion: (() -> Void)?) {
+    func showStatusBarNotificationWithMessage(_ message: String?, completion: (() -> Void)?) {
         
         self.createMessageLabelWithMessage(message)
         self.createSnapshotView()
@@ -127,8 +127,8 @@ extension StatusBarNotificationCenter {
         UIView.animate(withDuration: self.animateInLength, animations: { () -> Void in
             self.animateInFrameChange()
             }, completion: { (finished) -> Void in
-                let delayInSeconds = self.messageLabel.scrollTime
-                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(delayInSeconds * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: { () -> Void in
+                let delayInSeconds = lround(self.messageLabel.scrollTime)
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(delayInSeconds), execute: { () -> Void in
                     if let completion = completion {
                         completion()
                     }
@@ -139,7 +139,7 @@ extension StatusBarNotificationCenter {
   
     func showStatusBarNotificationWithMessage(_ message: String?, forDuration duration: TimeInterval) {
         self.showStatusBarNotificationWithMessage(message) { () -> Void in
-          DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(duration) * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: { () -> Void in
+          DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(lround(duration)), execute: { () -> Void in
             self.dismissNotification()
           })
         }
@@ -166,7 +166,7 @@ extension StatusBarNotificationCenter {
   
     func showStatusBarNotificationWithView(_ view: UIView, forDuration duration: TimeInterval) {
         self.showStatusBarNotificationWithView(view) { () -> Void in
-          DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(duration) * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: { () -> Void in
+          DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(lround(duration)), execute: { () -> Void in
             self.dismissNotification()
           })
         }

--- a/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
+++ b/Pod/Notification Center/StatusBarNotificationCenter+Logic.swift
@@ -182,7 +182,8 @@ extension StatusBarNotificationCenter {
     }
     
     func dismissNotificationWithCompletion(_ completion: (() -> Void)?) {
-        
+        guard notificationCenterConfiguration != nil else { return }
+		
         self.middleFrameChange()
         UIView.animate(withDuration: self.animateOutLength, animations: { () -> Void in
           self.animateOutFrameChange()


### PR DESCRIPTION
To know if a notification is dismissed completely it is necessary to listen for a tap gesture. If the notification is not dismissible, it should not catch the tap.

If the notification center receives a message to dismiss the currently shown notification, it should gracefully return instead of crashing the app.

Additionally, some Swift 3 optimization is done.
